### PR TITLE
Development for save_as_text_file

### DIFF
--- a/lib/spark/rdd.rb
+++ b/lib/spark/rdd.rb
@@ -1238,6 +1238,19 @@ module Spark
     end
 
 
+    # Save the RDD as a text file
+    #
+    # == Example:
+    #   rdd = $sc.parallelize([1,2,3,4,5])
+    #   rdd.save_as_text_file(path)
+    #
+    def save_as_text_file(path)
+      jrdd.saveAsTextFile(path)
+    end
+
+
+
+
     # Aliases
     alias_method :partitionsSize, :partitions_size
     alias_method :defaultReducePartitions, :default_reduce_partitions

--- a/spec/lib/save_spec.rb
+++ b/spec/lib/save_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+RSpec.describe 'Spark::RDD' do
+
+  context '.save_as_text_file' do
+    let(:file)    { File.join('spec', 'inputs', 'numbers_0_100.txt') }
+
+    def serializer
+      Spark::Serializer.build { __batched__(__marshal__, 1) }
+    end
+
+    def file_rdd
+      $sc.text_file(file, 2, Encoding::UTF_8, serializer)
+    end
+
+    def par_rdd
+      $sc.parallelize( (0..5).collect { |i| i.to_s }, 2, serializer)
+    end
+
+    it 'saves the file_rdd' do
+      Dir.mktmpdir do |tmpdir|
+        file_rdd.save_as_text_file(File.join(tmpdir,'file_rdd.txt'))
+        result = Dir.glob(File.join(tmpdir,'file_rdd.txt','*')).collect { |file| File.readlines(file).collect { |l| l.chomp } }.flatten
+
+        expect(result).to eq (0..100).collect { |i| i.to_s }
+      end
+    end
+
+    it 'saves the par_rdd' do
+      Dir.mktmpdir do |tmpdir|
+        par_rdd.save_as_text_file(File.join(tmpdir,'par_rdd.txt'))
+        result = Dir.glob(File.join(tmpdir,'par_rdd.txt','*')).collect { |file| File.readlines(file).collect { |l| l.chomp } }.flatten
+
+        expect(result).to eq (0..5).collect { |i| i.to_s }
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
So I want to contribute to this project and thought I'd start with something simple like saveAsTextFile.  Here's a spec that tries to save an RDD to a text file.  The thing I don't understand is that when the RDD is created from a text file, it works fine.  However, when the RDD is created from a parallelize command, the data that is written to the file becomes garbage.  Can you please help provide some insight into what's going wrong here?

    1) Spark::RDD .save_as_text_file saves the par_rdd
       Failure/Error: expect(result).to eq (0..5).collect { |i| i.to_s }
       
       expected: ["0", "1", "2", "3", "4", "5"]
            got: ["[B@2e293b50", "[B@14f518dd", "[B@67335fea", "[B@6b4b2ad1", "[B@13e8365f", "[B@7249a12e"]
       
       (compared using ==)
     # ./spec/lib/save_spec.rb:34:in `block (4 levels) in <top (required)>'
     # ./spec/lib/save_spec.rb:30:in `block (3 levels) in <top (required)>'
